### PR TITLE
posix: Set SA_RESTART for procmgr's signal handler

### DIFF
--- a/src/posix/st/procmgr.c
+++ b/src/posix/st/procmgr.c
@@ -64,7 +64,7 @@ int losiP_initprocmgr (losi_Alloc allocf, void *allocud)
 		/* setup signal action */
 		childact.sa_handler = SIG_DFL;
 		sigemptyset(&childact.sa_mask);
-		childact.sa_flags = 0;
+		childact.sa_flags = SA_RESTART;
 		/* setup signal block mask */
 		sigemptyset(&childmsk);
 		sigaddset(&childmsk, SIGCHLD);


### PR DESCRIPTION
Not all code can cope with EINTR on calls to e.g. read/write properly.
In particular, Lua itself cannot. So allow them to be restarted in order
to avoid those EINTR errors.